### PR TITLE
build: 启用viewBinding插件

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,10 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    viewBinding{
+        enabled = true
+    }
+//    启用viewBinding插件
 }
 
 dependencies {

--- a/app/src/main/java/com/example/traceassistant/MainActivity.kt
+++ b/app/src/main/java/com/example/traceassistant/MainActivity.kt
@@ -2,10 +2,14 @@ package com.example.traceassistant
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.LayoutInflater
+import com.example.traceassistant.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 }


### PR DESCRIPTION
viewBinding插件可以用更加方便高效的方式调用xml中的控件，而不需要写一堆getById；
同步后需要打开src目录下的build.gradle文件，文件页面上会有蓝底提示，点击sync。